### PR TITLE
Removed username trimming

### DIFF
--- a/backend/caldav/caldav.php
+++ b/backend/caldav/caldav.php
@@ -81,8 +81,6 @@ class BackendCalDAV extends BackendDiff {
      * @see IBackend::Logon()
      */
     public function Logon($username, $domain, $password) {
-        $parts = explode('@', $username);
-        $username = $parts[0];
         $this->_username = $username;
         $this->_caldav_path = str_replace('%u', $username, CALDAV_PATH);
         $this->_caldav = new CalDAVClient(CALDAV_SERVER . ":" . CALDAV_PORT . $this->_caldav_path, $username, $password);

--- a/backend/carddav/carddav.php
+++ b/backend/carddav/carddav.php
@@ -95,8 +95,6 @@ class BackendCardDAV extends BackendDiff implements ISearchProvider {
      * @return boolean
      */
     public function Logon($username, $domain, $password) {
-        $parts = explode('@', $username);
-        $username = $parts[0];
         $this->url = CARDDAV_PROTOCOL . '://' . CARDDAV_SERVER . ':' . CARDDAV_PORT . str_replace("%d", $domain, str_replace("%u", $username, CARDDAV_PATH));
         $this->default_url = CARDDAV_PROTOCOL . '://' . CARDDAV_SERVER . ':' . CARDDAV_PORT . str_replace("%d", $domain, str_replace("%u", $username, CARDDAV_DEFAULT_PATH));
         if (defined('CARDDAV_GAL_PATH')) {


### PR DESCRIPTION
Allowing the users to login into sogo using their email address makes this code (sometimes) wrong. It should still work, but not for the case when we have a user like this:
username: mjulian 
mail address: figarcorso@company.lte
